### PR TITLE
fix: Display escaped characters as-is in JSON values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-tapose",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useSimpleValueRenderer.ts
+++ b/src/hooks/useSimpleValueRenderer.ts
@@ -7,7 +7,16 @@ export const useSimpleValueRenderer = () => {
     if (value === undefined) return "";
     if (value === null) return "null";
 
-    if (typeof value === "string") return `"${value}"`;
+    if (typeof value === "string") {
+      // Handle all common escape characters
+      return `"${value
+        .replace(/\\/g, "\\\\") // Escape backslash first
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t")
+        .replace(/\f/g, "\\f")
+        .replace(/\v/g, "\\v")}"`;
+    }
     if (typeof value === "object") {
       // Display objects/arrays without abbreviation
       return JSON.stringify(value, null, 2)


### PR DESCRIPTION
# Escape character handling in JSON values

## Problem
When JSON values contained escape characters like `\n`, they were being rendered as actual line breaks in the UI, making it difficult to distinguish between intended string content and formatting.

## Solution
Modified the `renderSimpleValue` function in `useSimpleValueRenderer.ts` to properly escape special characters in string values:
- `\n` (newlines)
- `\r` (carriage returns)
- `\t` (tabs)
- `\f` (form feeds)
- `\v` (vertical tabs)
- `\\` (backslashes)

## Changes
- Updated string handling in `renderSimpleValue` to escape special characters before rendering
- Ensured backslashes are escaped first to maintain proper escaping order
- Maintained existing behavior for other value types
