### PR TITLE
fix: removes pull request trigger from workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-title: ""
-assignees: ""
-reviewers: "handsupmin"
----
-
 ## Changes
 
 Brief description of what this PR does

--- a/.github/workflows/azure-static-web-apps-lively-sky-00c893e00.yml
+++ b/.github/workflows/azure-static-web-apps-lively-sky-00c893e00.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
1. Removes the pull request trigger from the workflow configuration. 

This change simplifies the deployment process by only triggering on push events to the main branch, streamlining the workflow and avoiding unnecessary deployments.

2. Removes the title, assignees, and reviewers fields from the pull request template.

This streamlines the PR creation process by removing fields that are not always necessary, allowing contributors to focus on describing the changes and their purpose.
