### PR TITLE
fix: update subtitle to emphasize security

### DIFF
--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -34,5 +34,5 @@
   <text x="600" y="160" font-family="Arial, sans-serif" font-size="48" font-weight="bold" text-anchor="middle" fill="#0f172a">JSONtapose</text>
 
   <!-- Subtitle -->
-  <text x="600" y="500" font-family="Arial, sans-serif" font-size="28" text-anchor="middle" fill="#475569">Modern JSON Comparison Tool</text>
+  <text x="600" y="500" font-family="Arial, sans-serif" font-size="28" text-anchor="middle" fill="#475569">Secure JSON Comparison Tool</text>
 </svg>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -21,7 +21,7 @@ interface SEOProps {
  * Default SEO values for the application
  * These values are used when no props are provided
  */
-const DEFAULT_TITLE = "JSONtapose - Modern JSON Comparison Tool";
+const DEFAULT_TITLE = "JSONtapose - Secure JSON Comparison Tool";
 const DEFAULT_DESCRIPTION =
   "JSONtapose is a powerful JSON comparison tool that visualizes differences between two JSON objects in a side-by-side view. Compare, format and analyze JSON data easily.";
 const DEFAULT_KEYWORDS =


### PR DESCRIPTION
Replace "Modern" with "Secure" in the subtitle of the og-image and SEO component to better reflect the tool's capabilities. This change aims to highlight the tool's focus on secure JSON comparison.