### PR TITLE
chore(docs): Add Awesome JSON mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A secure, modern and high-performance JSON comparison tool that displays differences between JSON objects in a side-by-side view.
 
+[![Mentioned in Awesome JSON](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/burningtree/awesome-json#online-tools)
+
+Featured in [Awesome JSON](https://github.com/burningtree/awesome-json#online-tools), the JSON list linked from [sindresorhus/awesome](https://github.com/sindresorhus/awesome#miscellaneous). Added via [burningtree/awesome-json#229](https://github.com/burningtree/awesome-json/pull/229).
+
 ![JSONtapose Screenshot](screenshots/screenshot.png)
 
 ## Features


### PR DESCRIPTION
## Summary

- Add the official Awesome mentioned badge for Awesome JSON.
- Note that JSONtapose is listed in Awesome JSON, which is linked from sindresorhus/awesome.
- Include the merged awesome-json PR for provenance: https://github.com/burningtree/awesome-json/pull/229

## Validation

- Ran `git diff --check`.
- No app tests run; README-only documentation change.