### PR TITLE
ci: Split desktop artifacts by target

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -19,6 +16,7 @@ concurrency:
 jobs:
   web-and-extension:
     name: Web and browser extension
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -65,6 +63,7 @@ jobs:
 
   desktop-macos:
     name: Desktop macOS
+    if: github.ref == 'refs/heads/main'
     runs-on: macos-latest
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
@@ -98,11 +97,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-macos
-          path: release
+          path: |
+            release/*.dmg
+            release/*.zip
           if-no-files-found: error
 
   desktop-windows:
     name: Desktop Windows
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
 
     steps:
@@ -134,5 +136,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-windows
-          path: release
+          path: release/*.exe
           if-no-files-found: error

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -153,3 +153,62 @@ jobs:
             release/*.exe
             !release/*Setup*.exe
           if-no-files-found: error
+
+  cleanup-old-artifacts:
+    name: Cleanup old artifacts
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main' &&
+        needs.web-and-extension.result == 'success' &&
+        needs.desktop-macos.result == 'success' &&
+        needs.desktop-windows.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    needs:
+      - web-and-extension
+      - desktop-macos
+      - desktop-windows
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Delete previous Build Installables artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifactNames = new Set([
+              "web-dist",
+              "browser-extension-unpacked",
+              "desktop-macos-arm64",
+              "desktop-macos-x64",
+              "desktop-macos",
+              "desktop-windows-installer-x64",
+              "desktop-windows-portable-x64",
+              "desktop-windows",
+            ]);
+
+            const { owner, repo } = context.repo;
+            const currentRunId = context.runId;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              { owner, repo, per_page: 100 },
+            );
+
+            const staleArtifacts = artifacts.filter((artifact) => {
+              return (
+                artifactNames.has(artifact.name) &&
+                artifact.workflow_run?.id !== currentRunId
+              );
+            });
+
+            for (const artifact of staleArtifacts) {
+              await github.rest.actions.deleteArtifact({
+                owner,
+                repo,
+                artifact_id: artifact.id,
+              });
+              core.info(`Deleted ${artifact.name} from run ${artifact.workflow_run?.id}`);
+            }
+
+            core.info(`Deleted ${staleArtifacts.length} old artifact(s).`);

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -62,11 +62,19 @@ jobs:
           if-no-files-found: error
 
   desktop-macos:
-    name: Desktop macOS
+    name: Desktop macOS (${{ matrix.arch }})
     if: github.ref == 'refs/heads/main'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+          - arch: x64
+            runner: macos-15-intel
 
     steps:
       - name: Check out repository
@@ -91,19 +99,17 @@ jobs:
         run: pnpm build:desktop-main
 
       - name: Package macOS desktop app
-        run: pnpm exec electron-builder --mac --config electron-builder.yml --publish never
+        run: pnpm exec electron-builder --mac dmg --${{ matrix.arch }} --config electron-builder.yml --publish never
 
       - name: Upload macOS desktop artifact
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-macos
-          path: |
-            release/*.dmg
-            release/*.zip
+          name: desktop-macos-${{ matrix.arch }}
+          path: release/*.dmg
           if-no-files-found: error
 
   desktop-windows:
-    name: Desktop Windows
+    name: Desktop Windows (x64)
     if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
 
@@ -130,11 +136,20 @@ jobs:
         run: pnpm build:desktop-main
 
       - name: Package Windows desktop app
-        run: pnpm exec electron-builder --win --config electron-builder.yml --publish never
+        run: pnpm exec electron-builder --win --x64 --config electron-builder.yml --publish never
 
-      - name: Upload Windows desktop artifact
+      - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-windows
-          path: release/*.exe
+          name: desktop-windows-installer-x64
+          path: release/*Setup*.exe
+          if-no-files-found: error
+
+      - name: Upload Windows portable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows-portable-x64
+          path: |
+            release/*.exe
+            !release/*Setup*.exe
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Desktop behavior:
 - macOS: closing the window hides it and keeps JSONtapose available from the menu bar. Click the menu bar icon to show or hide the window. Right-click for the Open/Hide and Quit menu.
 - Windows: closing or minimizing hides the window and keeps JSONtapose available from the system tray. Use the tray icon or context menu to reopen or quit.
 
-Unsigned local macOS builds may require right-clicking the app and choosing **Open** the first time. Production distribution should add Apple and Windows signing credentials before public release.
+Unsigned macOS builds from local packaging or GitHub Actions artifacts may require right-clicking the app and choosing **Open** the first time. Production distribution should add Apple and Windows signing credentials before public release.
 
 ## Operator Runbook
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Builds are visible in **GitHub Actions**:
   - `desktop-windows-installer-x64`: Windows x64 NSIS installer
   - `desktop-windows-portable-x64`: Windows x64 portable executable
 
-To make a fresh build without pushing a new commit, open **Actions -> Build Installables -> Run workflow**. Artifacts appear at the bottom of the completed workflow run.
+To make a fresh build without pushing a new commit, open **Actions -> Build Installables -> Run workflow**. Artifacts appear at the bottom of the completed workflow run. After a successful run, older Build Installables artifacts are deleted so the latest artifact set remains available.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Builds are visible in **GitHub Actions**:
 - **Build Installables** builds and uploads operator-facing artifacts:
   - `web-dist`: static web build from `dist`
   - `browser-extension-unpacked`: unpacked Chrome/Edge extension from `dist-extension`
-  - `desktop-macos`: macOS Electron builds from `release`
-  - `desktop-windows`: Windows Electron builds from `release`
+  - `desktop-macos-arm64`: macOS Apple Silicon DMG
+  - `desktop-macos-x64`: macOS Intel DMG
+  - `desktop-windows-installer-x64`: Windows x64 NSIS installer
+  - `desktop-windows-portable-x64`: Windows x64 portable executable
 
 To make a fresh build without pushing a new commit, open **Actions -> Build Installables -> Run workflow**. Artifacts appear at the bottom of the completed workflow run.
 
@@ -97,9 +99,10 @@ Clipboard detection is off by default. When enabled in the popup, it detects str
 From GitHub Actions:
 
 1. Open **Actions -> Build Installables**.
-2. Download `desktop-macos` on macOS or `desktop-windows` on Windows.
-3. Unzip the artifact.
-4. Install or run the package from the `release` folder.
+2. On macOS, download `desktop-macos-arm64` for Apple Silicon or `desktop-macos-x64` for Intel.
+3. On Windows, download `desktop-windows-installer-x64` for the installer or `desktop-windows-portable-x64` for a portable executable.
+4. Unzip the artifact.
+5. Install or run the downloaded DMG or executable.
 
 Local packaging:
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,7 +10,6 @@ mac:
   category: public.app-category.developer-tools
   target:
     - dmg
-    - zip
 win:
   target:
     - nsis


### PR DESCRIPTION
## Changes

- Remove the `pull_request` trigger from Build Installables so it does not run for every PR branch.
- Add a `github.ref == refs/heads/main` job guard so manual dispatches only build from `main`.
- Split macOS desktop artifacts into Apple Silicon (`desktop-macos-arm64`) and Intel (`desktop-macos-x64`) DMGs.
- Upload macOS DMGs only, excluding generated zip and unpacked app folders.
- Split Windows x64 outputs into installer (`desktop-windows-installer-x64`) and portable (`desktop-windows-portable-x64`) artifacts.
- Add a cleanup job that deletes older Build Installables artifacts after a successful main run, keeping the latest artifact set.
- Clarify the renamed desktop artifacts, latest-artifact cleanup behavior, and unsigned macOS artifact behavior in README.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [x] Refactor

## Checklist

- [x] Self-tested the code
- [x] Self-reviewed the code
- [x] Code follows project style
- [x] Docs updated
- [ ] Tests added/updated (not applicable: workflow/docs-only change)

## Validation

- `git diff --check`
- Parsed `.github/workflows/build-artifacts.yml` and `electron-builder.yml` with Ruby YAML
- Checked the latest main Build Installables run logs and artifact metadata
- Verified local unsigned macOS app can launch when not quarantined; `spctl` rejects it as not properly signed
- Built local macOS DMGs for `arm64` and `x64` with `electron-builder --mac dmg --arm64` and `--x64`
- Confirmed the repository is public and #39 has no Build Installables run on the PR branch